### PR TITLE
Add AllowOffline feature flag for offline licenses

### DIFF
--- a/apis/licenses/v1alpha1/helper.go
+++ b/apis/licenses/v1alpha1/helper.go
@@ -24,6 +24,12 @@ func (l License) EnableClientBilling() bool {
 	return len(l.FeatureFlags) > 0 && l.FeatureFlags[FeatureEnableClientBilling] == "true"
 }
 
+// AllowOffline reports whether the license was issued for an offline
+// (air-gapped) deployment.
+func (l License) AllowOffline() bool {
+	return len(l.FeatureFlags) > 0 && l.FeatureFlags[FeatureAllowOffline] == "true"
+}
+
 func (l License) ActivationMode() ActivationMode {
 	if l.FeatureFlags[FeatureActivationMode] == string(ActivationModeCertification) {
 		return ActivationModeCertification

--- a/apis/licenses/v1alpha1/types.go
+++ b/apis/licenses/v1alpha1/types.go
@@ -74,6 +74,9 @@ const (
 	FeatureRestrictions        FeatureFlag = "Restrictions"
 	FeatureEnableClientBilling FeatureFlag = "EnableClientBilling"
 	FeatureActivationMode      FeatureFlag = "ActivationMode"
+	// FeatureAllowOffline marks a license that was issued for an offline
+	// (air-gapped) deployment. It is set (to "true") only for offline licenses.
+	FeatureAllowOffline FeatureFlag = "AllowOffline"
 )
 
 // +kubebuilder:validation:Enum=full;certification
@@ -84,7 +87,7 @@ const (
 	ActivationModeCertification ActivationMode = "certification"
 )
 
-var knownFlags = sets.New[FeatureFlag](FeatureDisableAnalytics, FeatureRestrictions, FeatureEnableClientBilling, FeatureActivationMode)
+var knownFlags = sets.New[FeatureFlag](FeatureDisableAnalytics, FeatureRestrictions, FeatureEnableClientBilling, FeatureActivationMode, FeatureAllowOffline)
 
 type FeatureFlags map[FeatureFlag]string
 


### PR DESCRIPTION
Introduce a dedicated FeatureAllowOffline feature flag ("AllowOffline") to mark licenses issued for offline (air-gapped) deployments, register it in knownFlags so FeatureFlags.IsValid accepts it, and add a License.AllowOffline() helper. Tagging offline licenses also makes them distinguishable from online ones at the certificate level, so switching a contract online<->offline forces the cached license certificate to be regenerated rather than reused.